### PR TITLE
Add --style support and some debug output

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ Available version are from 5 to 9.\
 Default: 9\
 Example: 9
 
+### `style`
+
+Style to use.\
+Results in the appropriate --style parameter.\
+Default: file\
+Example: chromium
+
 ## Example usage
 
 ```yml
@@ -53,7 +60,8 @@ jobs:
     - uses: DoozyX/clang-format-lint-action@v0.5
       with:
         source: '.'
-        exclude: './third_party'
+        exclude: './third_party ./external'
         extensions: 'h,cpp'
         clangFormatVersion: 9
+        style: chromium
 ```

--- a/action.yml
+++ b/action.yml
@@ -27,4 +27,11 @@ inputs:
     default: 'file'
 runs:
   using: 'docker'
-  image: 'docker://doozy/clang-format-lint:0.5'
+  image: 'Dockerfile'
+  args:
+    - --clang-format-executable /clang-format/clang-format${{ inputs.clangFormatVersion }}
+    - -r
+    - --style ${{ inputs.style }}
+    - --extensions ${{ inputs.extensions }}
+    - --exclude ${{ inputs.exclude }}
+    - ${{ inputs.source }}

--- a/action.yml
+++ b/action.yml
@@ -28,9 +28,3 @@ inputs:
 runs:
   using: 'docker'
   image: 'docker://doozy/clang-format-lint:0.5'
-  args:
-    - ${{ inputs.source }}
-    - ${{ inputs.exclude }}
-    - ${{ inputs.extensions }}
-    - ${{ inputs.clangFormatVersion }}
-    - ${{ inputs.style }}

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: 'Version of clang-format'
     required: false
     default: '9'
+  style:
+    description: 'Formatting style to use'
+    required: false
+    default: 'file'
 runs:
   using: 'docker'
   image: 'docker://doozy/clang-format-lint:0.5'
@@ -29,3 +33,4 @@ runs:
     - ${{ inputs.exclude }}
     - ${{ inputs.extensions }}
     - ${{ inputs.clangFormatVersion }}
+    - ${{ inputs.style }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,4 +3,4 @@
 cd "$GITHUB_WORKSPACE"
 
 ln -s /clang-format/clang-format${INPUT_CLANGFORMATVERSION} /usr/bin/clang-format
-/run-clang-format.py -r --exclude ${INPUT_EXCLUDE} --extensions ${INPUT_EXTENSIONS} ${INPUT_SOURCE}
+/run-clang-format.py -r --style="${INPUT_STYLE}" --exclude ${INPUT_EXCLUDE} --extensions ${INPUT_EXTENSIONS} ${INPUT_SOURCE}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,5 +2,4 @@
 
 cd "$GITHUB_WORKSPACE"
 
-ln -s /clang-format/clang-format${INPUT_CLANGFORMATVERSION} /usr/bin/clang-format
-/run-clang-format.py -r --style="${INPUT_STYLE}" --exclude ${INPUT_EXCLUDE} --extensions ${INPUT_EXTENSIONS} ${INPUT_SOURCE}
+/run-clang-format.py $*

--- a/run-clang-format.py
+++ b/run-clang-format.py
@@ -335,7 +335,11 @@ def main():
         extensions=args.extensions.split(','))
 
     if not files:
-        return
+        print_trouble(parser.prog, 'No files found', use_colors=colored_stderr)
+        return ExitStatus.TROUBLE
+
+    if not args.quiet:
+      print('Processing %s files: %s' % (len(files), ', '.join(files)))
 
     njobs = args.j
     if njobs == 0:

--- a/run-clang-format.py
+++ b/run-clang-format.py
@@ -131,6 +131,8 @@ def run_clang_format_diff(args, file):
     except IOError as exc:
         raise DiffError(str(exc))
     invocation = [args.clang_format_executable, file]
+    if args.style:
+      invocation.append('-style=' + args.style)
 
     # Use of utf-8 to decode the process output.
     #
@@ -278,6 +280,10 @@ def main():
         default=[],
         help='exclude paths matching the given glob-like pattern(s)'
         ' from recursive search')
+    parser.add_argument(
+        '--style',
+        help='Formatting style to use (default: file)',
+        default='file')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
This adds the missing `--style` param which defaults to `file` (most people have a style file)

It also outputs the number and paths of files to process and exists with an error if no files were found (ran into this and had nothing to verify the correctness of the action)

Finally it uses a simpler entrypoint.sh which forwards all arguments to the python script. It intentionally ignores whitespaces to allow multiple source and exclude folders as `source: 'extras libs tests'`

Closes #3
Fixes #7

Closes #5 (this is more focused)

BTW: I don't use the prebuild image for easier development. Building the image from the dockerfile takes 9s on GHA which is negligible.