### PR TITLE
Fix passing arguments with spaces

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,9 +29,13 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
-    - --clang-format-executable /clang-format/clang-format${{ inputs.clangFormatVersion }}
+    - --clang-format-executable
+    - /clang-format/clang-format${{ inputs.clangFormatVersion }}
     - -r
-    - --style ${{ inputs.style }}
-    - --extensions ${{ inputs.extensions }}
-    - --exclude ${{ inputs.exclude }}
+    - --style
+    - ${{ inputs.style }}
+    - --extensions
+    - ${{ inputs.extensions }}
+    - --exclude
+    - ${{ inputs.exclude }}
     - ${{ inputs.source }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,4 +2,4 @@
 
 cd "$GITHUB_WORKSPACE"
 
-/run-clang-format.py $*
+/run-clang-format.py "$@"


### PR DESCRIPTION
Allows usage of full style specs like `style: "{BasedOnStyle: Google, DerivePointerBinding: false, Standard: Cpp11}"`