### PR TITLE
Colorize output in github action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,8 @@ runs:
     - --clang-format-executable
     - /clang-format/clang-format${{ inputs.clangFormatVersion }}
     - -r
+    - --color
+    - always
     - --style
     - ${{ inputs.style }}
     - --inplace


### PR DESCRIPTION
I believe that we always want the output in github logs to be colored. If there are cases when we don't, I can make it set through action inputs.
Closes #43