### PR TITLE
Updating version of add-and-commit in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ jobs:
         extensions: 'h,cpp,c'
         clangFormatVersion: 14
         inplace: True
-    - uses: EndBug/add-and-commit@v4
+    - uses: EndBug/add-and-commit@v9
       with:
         author_name: Clang Robot
         author_email: robot@example.com


### PR DESCRIPTION
## General

First off, thanks for this great tool! When I started playing around with it earlier today I noticed I was getting some warnings about Node.js because I copy and pasted the example from the readme that used an old version of `add-and-commit`. After updating the version to the latest, the example ran without a problem.

## Details
For reference, here's the error github actions was showing: 
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: EndBug/add-and-commit@v4
