### PR TITLE
Allow directories with white-spaces to be passed

### DIFF
--- a/run-clang-format.py
+++ b/run-clang-format.py
@@ -257,6 +257,7 @@ def split_list_arg(arg):
     Otherwise it is returned unchanged
     Workaround for GHA not allowing list arguments
     """
+    # pattern matches all whitespaces except those preceded by a backslash, '\'
     pattern = r'(?<!\\)\s+'
     # if len(arg) == 1:
     #     # split list by regex

--- a/run-clang-format.py
+++ b/run-clang-format.py
@@ -243,7 +243,13 @@ def print_trouble(prog, message, use_colors):
         error_text = bold_red(error_text)
     print("{}: {} {}".format(prog, error_text, message), file=sys.stderr)
 
-
+def normalize_paths(paths):
+    """
+    Normalizes backward slashes in each path in list of paths
+    Ex)
+        "features/Test\ Features/feature.cpp" => "features/Test Features/feature.cpp"
+    """
+    return [path.replace("\\","") for path in paths]
 def split_list_arg(arg):
     """
     If arg is a list containing a single argument it is split into multiple elements.
@@ -255,7 +261,7 @@ def split_list_arg(arg):
         # split list by regex
         paths = re.split(pattern, arg[0])
         print(paths)
-        paths = [path.replace("\\","") for path in paths]
+        paths = normalize_paths(paths)
         # for path in paths:
         #     print(path)
         #     # normalize paths by removing forward slashes

--- a/run-clang-format.py
+++ b/run-clang-format.py
@@ -22,6 +22,7 @@ import signal
 import subprocess
 import sys
 import traceback
+import re
 from distutils.util import strtobool
 
 from functools import partial
@@ -69,6 +70,7 @@ def list_files(files, recursive=False, extensions=None, exclude=None):
 
     out = []
     for file in files:
+        file = file.replace("\\", "")
         if recursive and os.path.isdir(file):
             for dirpath, dnames, fnames in os.walk(file):
                 fpaths = [os.path.join(dirpath, fname) for fname in fnames]
@@ -248,6 +250,14 @@ def split_list_arg(arg):
     Otherwise it is returned unchanged
     Workaround for GHA not allowing list arguments
     """
+    pattern = r'(?<!\\)\s+'
+    if len(arg) == 1:
+        # split list by regex
+        paths = re.split(pattern, arg[0])
+        for path in paths:
+            # normalize paths by removing forward slashes
+            path = path.replace("\\", "")
+        return paths
     return arg[0].split() if len(arg) == 1 else arg
 
 

--- a/run-clang-format.py
+++ b/run-clang-format.py
@@ -70,7 +70,6 @@ def list_files(files, recursive=False, extensions=None, exclude=None):
 
     out = []
     for file in files:
-        # file = file.replace("\\", "")
         if recursive and os.path.isdir(file):
             for dirpath, dnames, fnames in os.walk(file):
                 fpaths = [os.path.join(dirpath, fname) for fname in fnames]
@@ -259,18 +258,6 @@ def split_list_arg(arg):
     """
     # pattern matches all whitespaces except those preceded by a backslash, '\'
     pattern = r'(?<!\\)\s+'
-    # if len(arg) == 1:
-    #     # split list by regex
-    #     paths = re.split(pattern, arg[0])
-    #     print(paths)
-    #     paths = normalize_paths(paths)
-    #     # for path in paths:
-    #     #     print(path)
-    #     #     # normalize paths by removing forward slashes
-    #     #     path = path.replace("\\", "dfgdf")
-    #     #     print(path)
-    #     print(paths)    
-    #     return paths
     return normalize_paths(re.split(pattern, arg[0])) if len(arg) == 1 else arg
 
 

--- a/run-clang-format.py
+++ b/run-clang-format.py
@@ -250,6 +250,7 @@ def normalize_paths(paths):
         "features/Test\ Features/feature.cpp" => "features/Test Features/feature.cpp"
     """
     return [path.replace("\\","") for path in paths]
+
 def split_list_arg(arg):
     """
     If arg is a list containing a single argument it is split into multiple elements.
@@ -257,19 +258,19 @@ def split_list_arg(arg):
     Workaround for GHA not allowing list arguments
     """
     pattern = r'(?<!\\)\s+'
-    if len(arg) == 1:
-        # split list by regex
-        paths = re.split(pattern, arg[0])
-        print(paths)
-        paths = normalize_paths(paths)
-        # for path in paths:
-        #     print(path)
-        #     # normalize paths by removing forward slashes
-        #     path = path.replace("\\", "dfgdf")
-        #     print(path)
-        print(paths)    
-        return paths
-    return arg[0].split() if len(arg) == 1 else arg
+    # if len(arg) == 1:
+    #     # split list by regex
+    #     paths = re.split(pattern, arg[0])
+    #     print(paths)
+    #     paths = normalize_paths(paths)
+    #     # for path in paths:
+    #     #     print(path)
+    #     #     # normalize paths by removing forward slashes
+    #     #     path = path.replace("\\", "dfgdf")
+    #     #     print(path)
+    #     print(paths)    
+    #     return paths
+    return normalize_paths(re.split(pattern, arg[0])) if len(arg) == 1 else arg
 
 
 def main():

--- a/run-clang-format.py
+++ b/run-clang-format.py
@@ -70,7 +70,7 @@ def list_files(files, recursive=False, extensions=None, exclude=None):
 
     out = []
     for file in files:
-        file = file.replace("\\", "")
+        # file = file.replace("\\", "")
         if recursive and os.path.isdir(file):
             for dirpath, dnames, fnames in os.walk(file):
                 fpaths = [os.path.join(dirpath, fname) for fname in fnames]
@@ -254,9 +254,14 @@ def split_list_arg(arg):
     if len(arg) == 1:
         # split list by regex
         paths = re.split(pattern, arg[0])
-        for path in paths:
-            # normalize paths by removing forward slashes
-            path = path.replace("\\", "")
+        print(paths)
+        paths = [path.replace("\\","") for path in paths]
+        # for path in paths:
+        #     print(path)
+        #     # normalize paths by removing forward slashes
+        #     path = path.replace("\\", "dfgdf")
+        #     print(path)
+        print(paths)    
         return paths
     return arg[0].split() if len(arg) == 1 else arg
 


### PR DESCRIPTION
This fixes #62 

Summary of Changes
---
`run-clang-format.py`:
- added `normalize_paths()` to normalize backslashes in all elements of a list of file paths.
  - I originally considered using [os.path.normpath](https://docs.python.org/3/library/os.path.html) but wasn't able to use it to normalize the backslashes
- extended `split_list_arg(arg)` to split arg by regex pattern (all white spaces except those preceded by a backslash) and then normalize any backslashes using `normalize_paths()`

Testing
---
The modified `run-clang-format.py` file was tested on **Ubuntu 18.04.6 LTS** using the following command:
```console
python3 ../../clang-format-lint-action/run-clang-format.py --clang-format-executable /usr/bin/clang-format-16 --inplace "true" --exte
nsions "h,cpp,c,hlsl,hlsli" --exclude "extern include" "features/Complex\ Parallax\ Materials/Shaders/ComplexParallaxMaterials/ComplexParallaxMaterials.hlsli src/Features/DistantTreeLighting.cpp"
```
...to replicate as many clang-format-lint arguments used in [this workflow](https://github.com/rjwignar/skyrim-community-shaders/actions/runs/6984314480/job/19006907593) (clang-format version, inplace, extensions, excludes), and succeeds:
```console
Processing 2 files: features/Complex Parallax Materials/Shaders/ComplexParallaxMaterials/ComplexParallaxMaterials.hlsli, src/Features/DistantTreeLighting.cpp
```

This of course, requires any and all whitespaces in the filepaths to be escaped by a backslash character `\`, otherwise filepaths will be broken apart just as before.
E.g.:
```console
python3 ../../clang-format-lint-action/run-clang-format.py --clang-format-executable /usr/bin/clang-format-16 --inplace "true" --extensions "h,cpp,c,hlsl,hlsli" --exclude "extern include" "features/Complex Parallax Materials/Shaders/ComplexParallaxMaterials/ComplexParallaxMaterials.hlsli src/Features/DistantTreeLighting.cpp"
``` 
will return:
```console
Processing 4 files: features/Complex, Parallax, Materials/Shaders/ComplexParallaxMaterials/ComplexParallaxMaterials.hlsli, src/Features/DistantTreeLighting.cpp
run-clang-format.py: error: [Errno 2] No such file or directory: 'Parallax'
run-clang-format.py: error: [Errno 2] No such file or directory: 'features/Complex'
run-clang-format.py: error: [Errno 2] No such file or directory: 'Materials/Shaders/ComplexParallaxMaterials/ComplexParallaxMaterials.hlsli'
```

I was able to test these changes locally by testing the Python script alone, but I want to try testing these changes as a GitHub Action. Is there a way I can do this?

 ---
Please let me know if additional changes are required.
Thank you for considering these changes.