### PR TITLE
fix: use custom strtobool if distutils not available

### DIFF
--- a/run-clang-format.py
+++ b/run-clang-format.py
@@ -23,7 +23,25 @@ import subprocess
 import sys
 import traceback
 import re
-from distutils.util import strtobool
+try:
+    from distutils.util import strtobool
+except ImportError:
+    def strtobool(val):
+        """
+        Convert a string representation of truth to true (1) or false (0).
+
+        True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+        are 'n', 'no', 'f', 'false', 'off', and '0'. Raises ValueError if
+        'val' is anything else.
+        """
+        val = val.lower()
+        if val in ('y', 'yes', 't', 'true', 'on', '1'):
+            return 1
+        elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+            return 0
+        else:
+            raise ValueError("Invalid truth value '{}'".format(val))
+
 
 from functools import partial
 


### PR DESCRIPTION
1) distutils not available from python 3.12 so clang-format-lint-action will fail.
2) strtobool is relatively simple function, we can use this function if the import fails.

inspiration:
1)  https://stackoverflow.com/questions/42248342/yes-no-prompt-in-python3-using-strtobool
